### PR TITLE
v0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "rust-niceware"
 description = "Generate or convert random bytes into passphrases. A Rust port of niceware."
 homepage = "https://github.com/healeycodes/rust-niceware"
 repository = "https://github.com/healeycodes/rust-niceware"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2018"
 license = "MIT"
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -24,3 +24,26 @@ impl Error for UnknownWordError {
         &self.details
     }
 }
+
+#[derive(Debug)]
+pub struct RNGError {
+    pub(crate) details: String,
+}
+impl RNGError {
+    pub(crate) fn new(msg: &str) -> RNGError {
+        RNGError {
+            details: msg.to_string(),
+        }
+    }
+}
+impl fmt::Display for RNGError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.details)
+    }
+}
+
+impl Error for RNGError {
+    fn description(&self) -> &str {
+        &self.details
+    }
+}


### PR DESCRIPTION
We don't need ownership of Vec buffers in `bytes_to_passphrase` and `passphrase_to_bytes`.

The arg to `generate_passphrase` can be named clearer to show it takes a random number of bytes.

Don't expose `ring`'s error type. Wrap it with the new `RNGError` to enable us to swap RNG crates in the future.